### PR TITLE
Suppress ESLint errors in dev mode

### DIFF
--- a/generateTemplate.js
+++ b/generateTemplate.js
@@ -18,12 +18,15 @@ function copyBaseTemplate() {
 function createTemplateJson() {
 	const defaults = require("cra-template/template.json");
 	const { devDependencies } = require("./package.json");
-	const eslintConfig = "@codeyourfuture/eslint-config-standard";
+	const sharedDeps = [
+		"@codeyourfuture/eslint-config-standard",
+		"cross-env",
+	];
 
 	const overrides = {
 		"package": {
 			"dependencies": {
-				[eslintConfig]: devDependencies[eslintConfig],
+				...sharedDeps.reduce((deps, dep) => ({ ...deps, [dep]: devDependencies[dep] }), {}),
 				"stop-runaway-react-effects": "^2.0.0",
 			},
 			"eslintConfig": {
@@ -38,6 +41,7 @@ function createTemplateJson() {
 			},
 			"scripts": {
 				"lint": "eslint .",
+				"start": "cross-env ESLINT_NO_DEV_ERRORS=true react-scripts start",
 				"test": "echo \"Error: no test specified\" && exit 1",
 			},
 		},


### PR DESCRIPTION
Thank you for contributing! To help the review process, please provide the following:

### Proposal
<!-- Provide a short description of the change you are proposing and the reasons for it. -->
Adds `cross-env` as a dependency to allow setting the `ESLINT_NO_DEV_ERRORS` environment variable to `true` in dev mode, which prevents new devs being spammed by linting errors when they're trying to run their app.

### Related
<!-- Provide links to any associated pull requests or issues. You can use `#123` to link to a PR or issue in this repository, or `user/repo#123` to link to other repositories. If none, just type N/A. -->
N/A

### Checklist

- [x] I have made this pull request to the `main` branch
- [x] I have run all of the automated validation (`npm run ship`)
- [ ] ~I have added myself to the `"contributors"` list in the `package.json` (or do not want to)~
